### PR TITLE
Bump client-side socket.io to 2.0.1

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -30,7 +30,7 @@ Mozilla presents an HTML5 mini-MMORPG by Little Workshop http://www.littleworksh
         <link rel="stylesheet" href="css/main.css" type="text/css">
         <link rel="stylesheet" href="css/achievements.css" type="text/css">
         <script src="js/lib/modernizr.js" type="text/javascript"></script>
-        <script src="https://cdn.socket.io/socket.io-1.3.5.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.0.1/socket.io.js"></script>
 
         <!--[if lt IE 9]>
                 <link rel="stylesheet" href="css/ie.css" type="text/css">


### PR DESCRIPTION
Hi Nenu,

Thanks for upgrading BrowserQuest to socket.io! I noticed that the client-side socket.io 1.5.3 failed with the latest server-side 2.0.1, at least on Windows & Linux, so I upgraded it. Apparently it also switched CDN.